### PR TITLE
Correct memory management.

### DIFF
--- a/Source/FaustProgram.cpp
+++ b/Source/FaustProgram.cpp
@@ -28,6 +28,7 @@ FaustProgram::~FaustProgram ()
 {
     delete faustInterface;
     delete dspInstance;
+    deleteDSPFactory(dspFactory);
 }
 
 bool FaustProgram::compileSource (juce::String source)
@@ -36,8 +37,10 @@ bool FaustProgram::compileSource (juce::String source)
 
     const char* argv[] = {""}; // compilation arguments
     std::string errorString;
+    
+    llvm_dsp_factory* formerFactory = dspFactory;
 
-    llvm_dsp_factory* factory = createDSPFactoryFromString
+    dspFactory = createDSPFactoryFromString
     (
         "faust", // program name
         source.toStdString (),
@@ -48,14 +51,14 @@ bool FaustProgram::compileSource (juce::String source)
     );
 
 
-    if (factory) // compilation successful!
+    if (dspFactory) // compilation successful!
     {
         llvm_dsp* formerInstance = dspInstance;
 
-        dspInstance = factory -> createDSPInstance ();
-
-        // delete factory; // we won't need this anymore
+        dspInstance = dspFactory -> createDSPInstance ();
+   
         delete formerInstance; // has been replaced
+        deleteDSPFactory(formerFactory);
         delete faustInterface; // to start fresh
 
         dspInstance -> init (sampleRate);

--- a/Source/FaustProgram.h
+++ b/Source/FaustProgram.h
@@ -19,11 +19,16 @@
 
 #pragma once
 
+// Use the Interprter backend instead of the LLVM backend
+//#define INTERP
+
 #include <JuceHeader.h>
-
+#ifdef INTERP
+#include <faust/dsp/interpreter-dsp.h>
+#else
 #include <faust/dsp/llvm-dsp.h>
+#endif
 #include <faust/gui/APIUI.h>
-
 
 // Wrapper around Faust-related stuff, namely:
 // - a Faust program
@@ -67,11 +72,10 @@ public:
 
 private:
 
-    llvm_dsp_factory* dspFactory = nullptr;
-    llvm_dsp* dspInstance = nullptr;
+    dsp_factory* dspFactory = nullptr;
+    dsp* dspInstance = nullptr;
     APIUI* faustInterface = nullptr;
     bool ready = false;
     int sampleRate;
-
 
 };

--- a/Source/FaustProgram.h
+++ b/Source/FaustProgram.h
@@ -67,6 +67,7 @@ public:
 
 private:
 
+    llvm_dsp_factory* dspFactory = nullptr;
     llvm_dsp* dspInstance = nullptr;
     APIUI* faustInterface = nullptr;
     bool ready = false;


### PR DESCRIPTION
The standalone or plugin was crashing when unloading/quitting. The DSP factory has to be properly deallocated. This PR fixes that.  